### PR TITLE
Solving wrong documentation example for disconnect

### DIFF
--- a/README.md
+++ b/README.md
@@ -84,7 +84,7 @@ angular
         })
 
         // Disconnect
-        $stomp.disconnect(function () {
+        $stomp.disconnect().then(function () {
           $log.info('disconnected')
         })
       })


### PR DESCRIPTION
The disconnect method is not receiving any callback. It returns a promise instead.
