### PR TITLE
Add notification when connection is broken

### DIFF
--- a/src/ng-stomp.js
+++ b/src/ng-stomp.js
@@ -28,9 +28,9 @@ angular
         var dfd = $q.defer()
 
         this.sock = new SockJS(endpoint)
-        this.sock.onclose = function() {
+        this.sock.onclose = function () {
           if (angular.isFunction(errorCallback)) {
-              errorCallback(new Error('Connection broken'))
+            errorCallback(new Error('Connection broken'))
           }
         }
 
@@ -41,7 +41,7 @@ angular
         }, function (err) {
           dfd.reject(err)
           if (angular.isFunction(errorCallback)) {
-              errorCallback(err)
+            errorCallback(err)
           }
         })
 

--- a/src/ng-stomp.js
+++ b/src/ng-stomp.js
@@ -28,6 +28,12 @@ angular
         var dfd = $q.defer()
 
         this.sock = new SockJS(endpoint)
+        this.sock.onclose = function() {
+          if (angular.isFunction(errorCallback)) {
+              errorCallback(new Error('Connection broken'))
+          }
+        }
+
         this.stomp = Stomp.over(this.sock)
         this.stomp.debug = this.debug
         this.stomp.connect(headers, function (frame) {
@@ -35,7 +41,7 @@ angular
         }, function (err) {
           dfd.reject(err)
           if (angular.isFunction(errorCallback)) {
-              errorCallback(err);
+              errorCallback(err)
           }
         })
 


### PR DESCRIPTION
When sockjs connection closes it notify the event through the error
callback. This way the error callback is always called to state that
connection is not available