### PR TITLE
Provide option to invoke callbacks within Scope.$apply

### DIFF
--- a/src/ng-stomp.js
+++ b/src/ng-stomp.js
@@ -42,7 +42,7 @@ angular
           dfd.reject(err)
           if (angular.isFunction(errorCallback)) {
             if (us.scopedApply) {
-              $rootScope.$apply(function() {
+              $rootScope.$apply(function () {
                 errorCallback(err)
               })
             } else {
@@ -70,9 +70,9 @@ angular
           } finally {
             if (angular.isFunction(callback)) {
               if (us.scopedApply) {
-                $rootScope.$apply(function() {
+                $rootScope.$apply(function () {
                   callback(payload, res.headers, res)
-                });
+                })
               } else {
                 callback(payload, res.headers, res)
               }


### PR DESCRIPTION
This introduces a new $stomp.setScopeApply(apply) option to simplify subscription callbacks that are making `$scope` content changes.

Here is an example of using this option:

```
.controller('MyCtrl', function ($scope, $stomp) {

    $stomp.setScopedApply(true);
    $scope.currentTime = 0;

    $stomp.connect('/ws', {})
        .then(function(frame){
            var subscription = $stomp.subscribe('/user/exchange/amq.direct/current-time', function(payload, headers, res){
                $scope.currentTime = payload.value;
            })
        })

})
```

It needs to be an opt-in feature since any existing users of `ng-stomp` might already be using `$scope.$apply` and recursive use causes the Angular error: `angular.js:14110 Error: [$rootScope:inprog] http://errors.angularjs.org/1.5.9/$rootScope/inprog?p0=%24apply`